### PR TITLE
(HF) Sokol to new PoA address

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -11,6 +11,9 @@
           "multi": {
             "0": {
               "safeContract": "0x8bf38d4764929064f2d4d3a56520a76ab3df415b"
+            },
+            "361171": {
+              "safeContract": "0xC1efa7A51fB5eD8e2293a55a9868256011B3579E"
             }
           }
         }


### PR DESCRIPTION
There is new PoA contract we I deployed today:
https://gist.github.com/rstormsf/1c175ecb30053a5ee8855c596e90d1a9

What is new?
We accidentally deployed old version of PoA to Sokol,
which didn't have the method
```
    function getCurrentValidatorsLength() public view returns(uint256) {
        return currentValidatorsLength;
    }
```
which is used in other contracts. We need to add this method in order to make other contracts work