### PR TITLE
Replace Roman Storm with Vadim Arasev in list of approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ List of approvers:
 - Igor Barinov
 - Viktor Baranov
 - Pavel Khahulin
-- Roman Storm
+- Vadim Arasev


### PR DESCRIPTION
This is a replacement of https://github.com/poanetwork/poa-chain-spec/pull/81 which was accidentally created to `sokol` instead of `core`