### PR TITLE
(Fix, Core) Revert Constantinople

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -34,10 +34,7 @@
     "eip140Transition": "0x0",
     "eip211Transition": "0x0",
     "eip214Transition": "0x0",
-    "eip658Transition": "0x0",
-    "eip145Transition": 6843780,
-    "eip1014Transition": 6843780,
-    "eip1052Transition": 6843780
+    "eip658Transition": "0x0"
   },
   "genesis": {
     "seal": {

--- a/spec.json
+++ b/spec.json
@@ -37,8 +37,7 @@
     "eip658Transition": "0x0",
     "eip145Transition": 6843780,
     "eip1014Transition": 6843780,
-    "eip1052Transition": 6843780,
-    "eip1283Transition": 6843780
+    "eip1052Transition": 6843780
   },
   "genesis": {
     "seal": {


### PR DESCRIPTION
This update removes from `spec.json` the Constantinople EIP transitions introduced in https://github.com/poanetwork/poa-chain-spec/pull/100.