### PR TITLE
(Fix, Sokol) Disable EIP-1283 in Sokol

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -41,7 +41,8 @@
     "eip145Transition": 6464300,
     "eip1014Transition": 6464300,
     "eip1052Transition": 6464300,
-    "eip1283Transition": 6464300
+    "eip1283Transition": 6464300,
+    "eip1283DisableTransition": 7026400
   },
   "genesis": {
     "seal": {


### PR DESCRIPTION
This update disables Constantinople EIP-1283 in `spec.json` for `Sokol` network which was introduced in #91.

The block number `7026400` (6 February, 12:00 UTC).

Should be merged after https://github.com/paritytech/parity-ethereum/pull/10223 is merged and a new version of Parity is released.