### PR TITLE
(Fix, xDai) Disable EIP-1283 in xDai

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -35,6 +35,7 @@
     "eip1014Transition": 1604400,
     "eip1052Transition": 1604400,
     "eip1283Transition": 1604400,
+    "eip1283DisableTransition": 2508800,
     "registrar": "0x1ec97dc137f5168af053c24460a1200502e1a9d2"
   },
   "genesis": {


### PR DESCRIPTION
This update disables Constantinople EIP-1283 in `spec.json` for `xDai` network which was introduced in #99.

The block number `2508800` (6 March, 12:00 UTC).

Instructions for `xDai` validators: https://github.com/poanetwork/wiki/wiki/HFs-xDai-2019-03-06