### PR TITLE
Kovan testnet HF for Validator set changing (15 May 2019)

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -7,17 +7,31 @@
 				"stepDuration": "0x4",
 				"blockReward": "0x4563918244F40000",
 				"validators": {
-					"list": [
-						"0x00D6Cc1BA9cf89BD2e58009741f4F7325BAdc0ED",
-						"0x00427feae2419c15b89d1c21af10d1b6650a4d3d",
-						"0x4Ed9B08e6354C70fE6F8CB0411b0d3246b424d6c",
-						"0x0020ee4Be0e2027d76603cB751eE069519bA81A1",
-						"0x0010f94b296a852aaac52ea6c5ac72e03afd032d",
-						"0x007733a1FE69CF3f2CF989F81C7b4cAc1693387A",
-						"0x00E6d2b931F55a3f1701c7389d592a7778897879",
-						"0x00e4a10650e5a6D6001C38ff8E64F97016a1645c",
-						"0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de"
-					]
+					"multi": {
+						"0": {
+							"list": [
+								"0x00D6Cc1BA9cf89BD2e58009741f4F7325BAdc0ED",
+								"0x00427feae2419c15b89d1c21af10d1b6650a4d3d",
+								"0x4Ed9B08e6354C70fE6F8CB0411b0d3246b424d6c",
+								"0x0020ee4Be0e2027d76603cB751eE069519bA81A1",
+								"0x0010f94b296a852aaac52ea6c5ac72e03afd032d",
+								"0x007733a1FE69CF3f2CF989F81C7b4cAc1693387A",
+								"0x00E6d2b931F55a3f1701c7389d592a7778897879",
+								"0x00e4a10650e5a6D6001C38ff8E64F97016a1645c",
+								"0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de"
+							]
+						},
+						"10960440": {
+							"list": [
+								"0x00D6Cc1BA9cf89BD2e58009741f4F7325BAdc0ED",
+								"0x0010f94b296a852aaac52ea6c5ac72e03afd032d",
+								"0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de"
+							]
+						},
+						"10960500": {
+							"safeContract": "0xaE71807C1B0a093cB1547b682DC78316D945c9B8"
+						}
+					}
 				},
 				"validateScoreTransition": "0x41a3c4",
 				"validateStepTransition": "0x16e360",


### PR DESCRIPTION
Changing the validator set in Kovan testnet to another set defined in the [`PoaNetworkConsensus`](https://github.com/poanetwork/poa-network-consensus-contracts/blob/kovan/contracts/PoaNetworkConsensus.sol) contract. Its address is [`0xaE71807C1B0a093cB1547b682DC78316D945c9B8`](https://kovan.etherscan.io/address/0xae71807c1b0a093cb1547b682dc78316d945c9b8#readContract). At the block `10960500` (15 May 2019, ~8 AM UTC) Kovan will be switched to the [POA Consensus model](https://github.com/poanetwork/poa-network-consensus-contracts/tree/kovan).

All the consensus contracts have been deployed in Kovan: their [addresses](https://github.com/poanetwork/poa-chain-spec/blob/kovan/contracts.json) and [ABIs](https://github.com/poanetwork/poa-chain-spec/tree/kovan/abis).

Validator set switching will be made in two steps:

1. At the block `10960440` the validator set will be switched to the hard-coded list of the current active validators:

    0x00D6Cc1BA9cf89BD2e58009741f4F7325BAdc0ED
    0x0010f94b296a852aaac52ea6c5ac72e03afd032d
    0x00a0a24b9f0e5ec7aa4c7389b8302fd0123194de

    That way, the inactive validators will be excluded from the validator set.

2. At the block `10960500` the validator set will be switched to the contract-based set defined in the [`PoaNetworkConsensus` contract](https://kovan.etherscan.io/address/0xae71807c1b0a093cb1547b682dc78316d945c9b8#readContract).

Old and new validators must update/install their Parity nodes to `v2.4.5` and use the new `spec.json` before the block `10960440`.

The new validator set defined in the `PoaNetworkConsensus` contract:
- [`POA`](https://forum.poa.network/t/poa-as-validator/2297)
- [`PepperSec.com`](https://forum.poa.network/t/peppersec-com-as-validator/2310)
- [`Lab10 (ARTIS)`](https://forum.poa.network/t/lab10-artis-as-validator/2347)
- [`Polymath.network`](https://forum.poa.network/t/polymath-network-as-validator/2339)