### PR TITLE
Add required eip1108_transition to spec

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -65,10 +65,47 @@
   ],
   "accounts": {
     "0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x0", "pricing": { "modexp": { "divisor": 20 } } } },
-    "0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": "0x0", "pricing": { "linear": { "base": 500, "word": 0 } } } },
-    "0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": "0x0", "pricing": { "linear": { "base": 40000, "word": 0 } } } },
-    "0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": "0x0", "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } }, 
-
+    "0000000000000000000000000000000000000006": {
+      "builtin": {
+        "activate_at": "0x0",
+        "name": "alt_bn128_add",
+        "eip1108_transition": "0x7fffffffffffff",
+        "pricing": {
+          "linear": {
+            "base": 500,
+            "word": 0
+          }
+        }
+      }
+    },
+    "0000000000000000000000000000000000000007": {
+      "builtin": {
+        "activate_at": "0x0",
+        "name": "alt_bn128_mul",
+        "eip1108_transition": "0x7fffffffffffff",
+        "pricing": {
+          "linear": {
+            "base": 40000,
+            "word": 0
+          }
+        }
+      }
+    },
+    "0000000000000000000000000000000000000008": {
+      "builtin": {
+        "activate_at": "0x0",
+        "name": "alt_bn128_pairing",
+        "eip1108_transition": "0x7fffffffffffff",
+        "pricing": {
+          "alt_bn128_pairing": {
+            "base": 100000,
+            "pair": 80000,
+            "eip1108_transition_base": 45000,
+            "eip1108_transition_pair": 34000
+          }
+        }
+      }
+    },
     "0x0000000000000000000000000000000000000001": {
       "balance": "1",
       "builtin": {


### PR DESCRIPTION
Tested sync with both `full` and `archive` sync using latest parity stable version:
https://github.com/paritytech/parity-ethereum/releases/tag/v2.5.9

Ref:
https://github.com/poanetwork/poa-chain-spec/pull/124
https://github.com/poanetwork/poa-chain-spec/pull/126