### PR TITLE
Add required eip1108_transition to spec

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -64,6 +64,7 @@
       "builtin": {
         "name": "alt_bn128_add",
         "activate_at": "0x0",
+        "eip1108_transition": "0x7fffffffffffff",
         "pricing": {
           "linear": {
             "base": 500,
@@ -76,6 +77,7 @@
       "builtin": {
         "name": "alt_bn128_mul",
         "activate_at": "0x0",
+        "eip1108_transition": "0x7fffffffffffff",
         "pricing": {
           "linear": {
             "base": 40000,
@@ -88,10 +90,13 @@
       "builtin": {
         "name": "alt_bn128_pairing",
         "activate_at": "0x0",
+        "eip1108_transition": "0x7fffffffffffff",
         "pricing": {
           "alt_bn128_pairing": {
             "base": 100000,
-            "pair": 80000
+            "pair": 80000,
+            "eip1108_transition_base": 45000,
+            "eip1108_transition_pair": 34000
           }
         }
       }


### PR DESCRIPTION
Tested sync with both `full` and `archive` sync using latest parity stable version:
https://github.com/paritytech/parity-ethereum/releases/tag/v2.5.9

Ref:
https://github.com/poanetwork/poa-chain-spec/pull/124
https://github.com/poanetwork/poa-chain-spec/pull/125