### PR TITLE
(xDai) Update spec for Istanbul

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -36,6 +36,11 @@
     "eip1052Transition": 1604400,
     "eip1283Transition": 1604400,
     "eip1283DisableTransition": 2508800,
+    "eip1283ReenableTransition": 7298030,
+    "eip1344Transition": 7298030,
+    "eip1706Transition": 7298030,
+    "eip1884Transition": 7298030,
+    "eip2028Transition": 7298030,
     "registrar": "0x1ec97dc137f5168af053c24460a1200502e1a9d2"
   },
   "genesis": {
@@ -49,49 +54,99 @@
     "gasLimit": "0x989680"
   },
   "accounts": {
-    "0000000000000000000000000000000000000005": {
+    "0x0000000000000000000000000000000000000005": {
       "builtin": {
         "name": "modexp",
-        "activate_at": "0x0",
         "pricing": {
-          "modexp": {
-            "divisor": 20
+          "0": {
+            "price": {
+              "modexp": {
+                "divisor": 20
+              }
+            }
           }
         }
       }
     },
-    "0000000000000000000000000000000000000006": {
+    "0x0000000000000000000000000000000000000006": {
       "builtin": {
         "name": "alt_bn128_add",
-        "activate_at": "0x0",
         "pricing": {
-          "linear": {
-            "base": 500,
-            "word": 0
+          "0": {
+            "price": {
+              "alt_bn128_const_operations": {
+                "price": 500
+              }
+            }
+          },
+          "7298030": {
+            "info": "Istanbul HF",
+            "price": {
+              "alt_bn128_const_operations": {
+                "price": 150
+              }
+            }
           }
         }
       }
     },
-    "0000000000000000000000000000000000000007": {
+    "0x0000000000000000000000000000000000000007": {
       "builtin": {
         "name": "alt_bn128_mul",
-        "activate_at": "0x0",
         "pricing": {
-          "linear": {
-            "base": 40000,
-            "word": 0
+          "0": {
+            "price": {
+              "alt_bn128_const_operations": {
+                "price": 40000
+              }
+            }
+          },
+          "7298030": {
+            "info": "Istanbul HF",
+            "price": {
+              "alt_bn128_const_operations": {
+                "price": 6000
+              }
+            }
           }
         }
       }
     },
-    "0000000000000000000000000000000000000008": {
+    "0x0000000000000000000000000000000000000008": {
       "builtin": {
         "name": "alt_bn128_pairing",
-        "activate_at": "0x0",
         "pricing": {
-          "alt_bn128_pairing": {
-            "base": 100000,
-            "pair": 80000
+          "0": {
+            "price": {
+              "alt_bn128_pairing": {
+                "base": 100000,
+                "pair": 80000
+              }
+            }
+          },
+          "7298030": {
+            "info": "Istanbul HF",
+            "price": {
+              "alt_bn128_pairing": {
+                "base": 45000,
+                "pair": 34000
+              }
+            }
+          }
+        }
+      }
+    },
+    "0x0000000000000000000000000000000000000009": {
+      "builtin": {
+        "name": "blake2_f",
+        "pricing": {
+          "7298030": {
+            "info": "Istanbul HF",
+            "price": {
+              "blake2_f": {
+                "gas_per_round": 1
+              }
+            }
           }
         }
       }
@@ -101,9 +156,13 @@
       "builtin": {
         "name": "ecrecover",
         "pricing": {
-          "linear": {
-            "base": 3000,
-            "word": 0
+          "0": {
+            "price": {
+              "linear": {
+                "base": 3000,
+                "word": 0
+              }
+            }
           }
         }
       }
@@ -113,9 +172,13 @@
       "builtin": {
         "name": "sha256",
         "pricing": {
-          "linear": {
-            "base": 60,
-            "word": 12
+          "0": {
+            "price": {
+              "linear": {
+                "base": 60,
+                "word": 12
+              }
+            }
           }
         }
       }
@@ -125,9 +188,13 @@
       "builtin": {
         "name": "ripemd160",
         "pricing": {
-          "linear": {
-            "base": 600,
-            "word": 120
+          "0": {
+            "price": {
+              "linear": {
+                "base": 600,
+                "word": 120
+              }
+            }
           }
         }
       }
@@ -137,9 +204,13 @@
       "builtin": {
         "name": "identity",
         "pricing": {
-          "linear": {
-            "base": 15,
-            "word": 3
+          "0": {
+            "price": {
+              "linear": {
+                "base": 15,
+                "word": 3
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
The `Istanbul HF` in `xDai` is about to be activated at block `7298030` (~`Thursday, 12-Dec-19 07:00 UTC`).

This HF requires updating nodes to `Parity v2.6.5` since `spec.json` format is changed in that version: https://github.com/paritytech/parity-ethereum/pull/11039

The corresponding PR in Parity repository: https://github.com/paritytech/parity-ethereum/pull/11299