### PR TITLE
(Core) Update spec for Istanbul

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -38,7 +38,12 @@
     
     "eip145Transition": 8582254,
     "eip1014Transition": 8582254,
-    "eip1052Transition": 8582254
+    "eip1052Transition": 8582254,
+    "eip1283Transition": 12598600,
+    "eip1344Transition": 12598600,
+    "eip1706Transition": 12598600,
+    "eip1884Transition": 12598600,
+    "eip2028Transition": 12598600
   },
   "genesis": {
     "seal": {
@@ -59,19 +64,115 @@
     "enode://96678da10ac83769ab3f63114a41b57b700476c5ac02719b878fa89909a936551bb7609aa09b068bf89903206fa03f23e1b5b9117ca278de304c2570b87dcb27@35.175.15.164:30303"
   ],
   "accounts": {
-    "0000000000000000000000000000000000000005": { "builtin": { "name": "modexp", "activate_at": "0x0", "pricing": { "modexp": { "divisor": 20 } } } },
-    "0000000000000000000000000000000000000006": { "builtin": { "name": "alt_bn128_add", "activate_at": "0x0", "pricing": { "linear": { "base": 500, "word": 0 } } } },
-    "0000000000000000000000000000000000000007": { "builtin": { "name": "alt_bn128_mul", "activate_at": "0x0", "pricing": { "linear": { "base": 40000, "word": 0 } } } },
-    "0000000000000000000000000000000000000008": { "builtin": { "name": "alt_bn128_pairing", "activate_at": "0x0", "pricing": { "alt_bn128_pairing": { "base": 100000, "pair": 80000 } } } }, 
-
+    "0x0000000000000000000000000000000000000005": {
+      "builtin": {
+        "name": "modexp",
+        "pricing": {
+          "0": {
+            "price": {
+              "modexp": {
+                "divisor": 20
+              }
+            }
+          }
+        }
+      }
+    },
+    "0x0000000000000000000000000000000000000006": {
+      "builtin": {
+        "name": "alt_bn128_add",
+        "pricing": {
+          "0": {
+            "price": {
+              "alt_bn128_const_operations": {
+                "price": 500
+              }
+            }
+          },
+          "12598600": {
+            "info": "Istanbul HF",
+            "price": {
+              "alt_bn128_const_operations": {
+                "price": 150
+              }
+            }
+          }
+        }
+      }
+    },
+    "0x0000000000000000000000000000000000000007": {
+      "builtin": {
+        "name": "alt_bn128_mul",
+        "pricing": {
+          "0": {
+            "price": {
+              "alt_bn128_const_operations": {
+                "price": 40000
+              }
+            }
+          },
+          "12598600": {
+            "info": "Istanbul HF",
+            "price": {
+              "alt_bn128_const_operations": {
+                "price": 6000
+              }
+            }
+          }
+        }
+      }
+    },
+    "0x0000000000000000000000000000000000000008": {
+      "builtin": {
+        "name": "alt_bn128_pairing",
+        "pricing": {
+          "0": {
+            "price": {
+              "alt_bn128_pairing": {
+                "base": 100000,
+                "pair": 80000
+              }
+            }
+          },
+          "12598600": {
+            "info": "Istanbul HF",
+            "price": {
+              "alt_bn128_pairing": {
+                "base": 45000,
+                "pair": 34000
+              }
+            }
+          }
+        }
+      }
+    },
+    "0x0000000000000000000000000000000000000009": {
+      "builtin": {
+        "name": "blake2_f",
+        "pricing": {
+          "12598600": {
+            "info": "Istanbul HF",
+            "price": {
+              "blake2_f": {
+                "gas_per_round": 1
+              }
+            }
+          }
+        }
+      }
+    },
     "0x0000000000000000000000000000000000000001": {
       "balance": "1",
       "builtin": {
         "name": "ecrecover",
         "pricing": {
-          "linear": {
-            "base": 3000,
-            "word": 0
+          "0": {
+            "price": {
+              "linear": {
+                "base": 3000,
+                "word": 0
+              }
+            }
           }
         }
       }
@@ -81,9 +182,13 @@
       "builtin": {
         "name": "sha256",
         "pricing": {
-          "linear": {
-            "base": 60,
-            "word": 12
+          "0": {
+            "price": {
+              "linear": {
+                "base": 60,
+                "word": 12
+              }
+            }
           }
         }
       }
@@ -93,9 +198,13 @@
       "builtin": {
         "name": "ripemd160",
         "pricing": {
-          "linear": {
-            "base": 600,
-            "word": 120
+          "0": {
+            "price": {
+              "linear": {
+                "base": 600,
+                "word": 120
+              }
+            }
           }
         }
       }
@@ -105,9 +214,13 @@
       "builtin": {
         "name": "identity",
         "pricing": {
-          "linear": {
-            "base": 15,
-            "word": 3
+          "0": {
+            "price": {
+              "linear": {
+                "base": 15,
+                "word": 3
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
The `Istanbul HF` in `Core` is about to be activated at block `12598600` (~`Thursday, 19-Dec-2019 07:00 UTC`).

This HF requires updating nodes to `Parity v2.6.5` since `spec.json` format is changed in that version: https://github.com/paritytech/parity-ethereum/pull/11039

The corresponding PR in Parity repository: https://github.com/paritytech/parity-ethereum/pull/11298