### PR TITLE
(Sokol) Activate on-chain randomness

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -24,7 +24,10 @@
           }
         },
         "blockRewardContractAddress": "0x3145197AD50D7083D0222DE4fCCf67d9BD05C30D",
-        "blockRewardContractTransition": 4639000
+        "blockRewardContractTransition": 4639000,
+        "randomnessContractAddress": {
+          "13391641": "0x8f2b78169B0970F11a762e56659Db52B59CBCf1B"
+        }
       }
     }
   },


### PR DESCRIPTION
The `spec.json` is changed for `Sokol` chain to activate the on-chain randomness described in https://www.poa.network/for-developers/on-chain-random-numbers.

The changed spec requires a validator to have **Parity Ethereum v2.7.2** node.

The activation will occur at block `#13391641` (20 February 2020 ~08:00 am UTC).

