### PR TITLE
(Core) Activate on-chain randomness

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -21,7 +21,10 @@
           }
         },
         "blockRewardContractAddress": "0x4d0153D434384128D17243409e02fca1B3EE21D6",
-        "blockRewardContractTransition": 5761140
+        "blockRewardContractTransition": 5761140,
+        "randomnessContractAddress": {
+          "14350721": "0x67e90a54AeEA85f21949c645082FE95d77BC1E70"
+        }
       }
     }
   },


### PR DESCRIPTION
The `spec.json` is changed for `POA Core` chain to activate the on-chain randomness described in https://www.poa.network/for-developers/on-chain-random-numbers.

The changed spec requires a validator to have **Parity Ethereum v2.7.2** node.

The activation will occur at block `#14350721` (31 March 2020 ~05:51 pm UTC).
