### PR TITLE
(Core) Berlin HF

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -46,7 +46,9 @@
     "eip1344Transition": 12598600,
     "eip1706Transition": 12598600,
     "eip1884Transition": 12598600,
-    "eip2028Transition": 12598600
+    "eip2028Transition": 12598600,
+    "eip2929Transition": 21364900,
+    "eip2930Transition": 21364900
   },
   "genesis": {
     "seal": {
@@ -76,6 +78,12 @@
               "modexp": {
                 "divisor": 20
               }
+            }
+          },
+          "21364900": {
+            "info": "EIP-2565: ModExp Gas Cost. Berlin hardfork (May 24, 2021, ~10:00 am UTC)",
+            "price": {
+              "modexp2565": {}
             }
           }
         }


### PR DESCRIPTION
We are going to activate Berlin HF on POA Core at `~10:00 am UTC, May 24` (block `21 364 900`).