### PR TITLE
(Core) Set min base fee on POA Core to 10 GWei

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -56,6 +56,8 @@
     "eip1559BaseFeeMaxChangeDenominator": "0x8",
     "eip1559ElasticityMultiplier": "0x2",
     "eip1559BaseFeeInitialValue": "0x3b9aca00",
+    "eip1559BaseFeeMinValue": "0x2540be400",
+    "eip1559BaseFeeMinValueTransition": 24199500,
     "eip1559FeeCollector": "0x517F3AcfF3aFC2fb45e574718bca6F919b798e10",
     "eip1559FeeCollectorTransition": 24090200
   },


### PR DESCRIPTION
The transition is scheduled for block `24199500` (November 8, 2021).